### PR TITLE
Refactor code to have instances of OBMData per NR

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ export default class TogglOBMHelper {
    */
   isIncluded () {
     this.checkIsFetched()
-    return this.obmData.included === true
+    return this.obmData.included
   }
 
   /**
@@ -97,7 +97,7 @@ export default class TogglOBMHelper {
    */
   isExcluded () {
     this.checkIsFetched()
-    return this.obmData.included === false
+    return !this.obmData.included
   }
 
   /**
@@ -142,7 +142,8 @@ export default class TogglOBMHelper {
     return this.getData(key) != null
   }
   getBool (key) {
-    return this.getData(key) === '1'
+    const value = this.getData(key)
+    return value === '1' || value === 'true'
   }
   saveBool (key, bool) {
     this.saveData(key, bool && '1' || '0')

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,22 +11,52 @@ import _ from 'lodash'
 import Promise from 'bluebird'
 import {setAuthHeader, getAPIUrl} from './utils'
 
+const obmCache = {}
+
+class OBMData {
+  included: boolean;
+  actions: string;
+  fetched: boolean;
+  fetchRequest: ?Promise;
+
+  constructor () {
+    this.included = false
+    this.actions = ''
+    this.fetched = false
+    this.fetchRequest = null
+  }
+
+  update ({included, actions}) {
+    if (included != null) this.included = included
+    if (actions != null) this.actions = actions
+    this.fetched = true
+    this.fetchRequest = null
+  }
+
+  static getInstanceFor (userId: number, nr: number) : OBMData {
+    let userData = obmCache[userId]
+    if (!userData) {
+      userData = {}
+      obmCache[userId] = userData
+    }
+    let obmData = userData[nr]
+    if (!obmData) {
+      obmData = new OBMData(nr)
+      userData[nr] = obmData
+    }
+    return obmData
+  }
+}
+
 export default class TogglOBMHelper {
+  nr: number;
+  userId: number;
+  obmData: OBMData;
 
   constructor (nr: number, userId: number, forceFetch: boolean = false) {
     this.nr = nr
-    this._user = userCache[userId]
-    if (this._user == null) {
-      this._user = {
-        id: userId,
-        nr: -1,
-        included: false,
-        actions: '',
-        fetched: false,
-        fetchRequest: null
-      }
-      userCache[userId] = this._user
-    }
+    this.userId = userId
+    this.obmData = OBMData.getInstanceFor(userId, nr)
     this.ready()
   }
 
@@ -35,42 +65,21 @@ export default class TogglOBMHelper {
    * The OBMHelper instances check this data to know whether they are running,
    * or the logged user is included.
    */
-  mock ({nr, included, actions}) {
-    if (nr != null) {
-      if (typeof nr !== 'number') {
-        throw new TypeError('Mocked `nr` should be a number')
+  mock ({included, actions}) {
+    var mockData = new OBMData(this.obmData.nr)
+    mockData.update({included, actions})
+    for (var prop in arguments[0]) {
+      if (!mockData.hasOwnProperty(prop)) {
+        throw new Error(`Can't mock property '${prop}'.`)
       }
-      this._user.nr = nr
     }
-    if (included != null) {
-      if (typeof included !== 'boolean') {
-        throw new TypeError('Mocked `included` should be a boolean')
-      }
-      this._user.included = included
-    }
-    if (actions != null) {
-      if (typeof actions !== 'string') {
-        throw new TypeError('Mocked `actions` should be a string')
-      }
-      this._user.actions = actions
-    }
-    this._user.fetched = true
-    this._user.fetchRequest = null
+    this.obmData = mockData
   }
 
   checkIsFetched () {
-    if (!this._user.fetched) {
-      throw new Error('OBMHelper didn\'t fetch user data yet.')
+    if (!this.obmData.fetched) {
+      throw new Error(`OBM ${this.nr} data hasn't been fetched yet.`)
     }
-  }
-
-  /**
-   * Checks whether the experiment is currently being allocated more users to.
-   * @return {Boolean} running
-   */
-  isRunning () {
-    this.checkIsFetched()
-    return this.nr === this._user.nr
   }
 
   /**
@@ -79,7 +88,7 @@ export default class TogglOBMHelper {
    */
   isIncluded () {
     this.checkIsFetched()
-    return this.isRunning() && this._user.included === true
+    return this.obmData.included === true
   }
 
   /**
@@ -88,7 +97,7 @@ export default class TogglOBMHelper {
    */
   isExcluded () {
     this.checkIsFetched()
-    return this.isRunning() && this._user.included === false
+    return this.obmData.included === false
   }
 
   /**
@@ -99,7 +108,7 @@ export default class TogglOBMHelper {
    */
   getActionExists (action) {
     this.checkIsFetched()
-    const actions = this._user.actions.split(',')
+    const actions = this.obmData.actions.split(',')
     const exists = _.indexOf(actions, action) > -1
     return exists
   }
@@ -111,7 +120,7 @@ export default class TogglOBMHelper {
    * @return {String} storageKey
    */
   getStorageKey (key) {
-    return `obm${ this.nr }_${ key }_${ this._user.id }`
+    return `obm${ this.nr }_${ key }_${ this.userId }`
   }
 
   /**
@@ -176,6 +185,9 @@ export default class TogglOBMHelper {
       type: 'POST',
       url: getAPIUrl('obm/actions', 9)
     })
+    if (!this.getActionExists(key)) {
+      this.obmData.actions += `,${key}`
+    }
   }
 
   /**
@@ -184,27 +196,32 @@ export default class TogglOBMHelper {
    * @return {Promise}
    */
   fetch () {
-    let fetchRequest = this._user.fetchRequest
+    let fetchRequest = this.obmData.fetchRequest
     if (fetchRequest == null) {
       fetchRequest = new Promise((resolve, reject) => {
         $.ajax({
           beforeSend: setAuthHeader,
           type: 'GET',
           url: getAPIUrl('me/experiments/web', 9),
-          success: data => {
-            this.mock(data)
+          success: ({nr, included, actions }) => {
+            if (nr === this.nr) {
+              this.obmData.update({ included, actions })
+            } else {
+              this.obmData.fetched = true
+              this.obmData.fetchRequest = null
+            }
             resolve(this)
           },
           error: err => {
             // In case data has been mocked or refetched, ignore failure
-            if (this._user.fetchRequest === fetchRequest) {
-              this._user.fetchRequest = null
+            if (this.obmData.fetchRequest === fetchRequest) {
+              this.obmData.fetchRequest = null
               reject(err)
             }
           }
         })
       })
-      this._user.fetchRequest = fetchRequest
+      this.obmData.fetchRequest = fetchRequest
     }
     return fetchRequest
   }
@@ -215,12 +232,9 @@ export default class TogglOBMHelper {
    * @return {Promise}
    */
   ready () {
-    if (this._user.fetched) {
+    if (this.obmData.fetched) {
       return Promise.resolve(this)
     }
     return this.fetch()
   }
 }
-
-const userCache = {}
-TogglOBMHelper.userCache = userCache

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toggl-obm-helper",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Helper module for OBM experiments.",
   "author": "David da Silva <dasilvacontin@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
- Allows mocking data per `TogglOBMHelper` instance, without affecting
  other instances - how it was supposed to be.

- Stores an OBMData instance per NR, that is shared between
  TogglOBMHelpers for that NR. Allows storing sent actions.

- Removed pointless/redundant/error-prone method `isRunning`.