### PR TITLE
Fix not setting data if helper didnt trigger initial request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -178,6 +178,7 @@ export default class TogglOBMHelper {
    * @param {String} [value], default to `true` for backwards compatibility
    */
   sendAction (key: string, value: any = 'true') {
+    if (this.getActionExists(key)) return
     value = String(value)
     const payload = { experiment_id: this.nr, key, value }
     $.ajax({

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,10 @@ export default class TogglOBMHelper {
    */
   isIncluded () : boolean {
     this.checkIsFetched()
-    return this.obmData.included
+    const included = this.obmData.included
+    const wasIncluded = this.getBool('was_included')
+    if (included && !wasIncluded) this.saveBool('was_included', true)
+    return (included || wasIncluded)
   }
 
   /**
@@ -95,7 +98,7 @@ export default class TogglOBMHelper {
    */
   isExcluded () : boolean {
     this.checkIsFetched()
-    return !this.obmData.included
+    return !this.isIncluded()
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,25 +12,23 @@ import Promise from 'bluebird'
 import {setAuthHeader, getAPIUrl} from './utils'
 
 const obmCache = {}
+let fetchRequest: ?Promise = null
 
 class OBMData {
   included: boolean;
   actions: string;
   fetched: boolean;
-  fetchRequest: ?Promise;
 
   constructor () {
     this.included = false
     this.actions = ''
     this.fetched = false
-    this.fetchRequest = null
   }
 
   update ({included, actions}) {
     if (included != null) this.included = included
     if (actions != null) this.actions = actions
     this.fetched = true
-    this.fetchRequest = null
   }
 
   static getInstanceFor (userId: number, nr: number) : OBMData {
@@ -196,35 +194,46 @@ export default class TogglOBMHelper {
    * fullfilled whenever the OBM data finishes fetching
    * @return {Promise}
    */
-  fetch () : Promise {
-    let fetchRequest = this.obmData.fetchRequest
-    if (fetchRequest == null) {
-      fetchRequest = new Promise((resolve, reject) => {
+  fetch ({ force = true } = {}) : Promise {
+    if (fetchRequest == null || force) {
+      const req = new Promise((resolve, reject) => {
         $.ajax({
           beforeSend: setAuthHeader,
           type: 'GET',
           url: getAPIUrl('me/experiments/web', 9),
-          success: ({nr, included, actions }) => {
-            if (nr === this.nr) {
-              this.obmData.update({ included, actions })
-            } else {
-              this.obmData.fetched = true
-              this.obmData.fetchRequest = null
+          success: data => {
+            if (req === fetchRequest) {
+              fetchRequest = null
             }
-            resolve(this)
+            resolve(data)
           },
           error: err => {
-            // In case data has been mocked or refetched, ignore failure
-            if (this.obmData.fetchRequest === fetchRequest) {
-              this.obmData.fetchRequest = null
-              reject(err)
+            if (req === fetchRequest) {
+              fetchRequest = null
             }
+            reject(err)
           }
         })
       })
-      this.obmData.fetchRequest = fetchRequest
+      fetchRequest = req
     }
-    return fetchRequest
+    return new Promise((resolve, reject) => {
+      fetchRequest.then((data) => {
+        const { nr, included, actions } = data
+        if (nr === this.nr) {
+          this.obmData.update({ included, actions })
+        }
+        this.obmData.fetched = true
+        resolve(this)
+        return data
+      }, err => {
+        console.log(err)
+        this.obmData.fetched = true
+        resolve(this)
+        // execute following .then handlers
+        return { nr: -1, included: false, actions: '' }
+      })
+    })
   }
 
   /**
@@ -236,6 +245,6 @@ export default class TogglOBMHelper {
     if (this.obmData.fetched) {
       return Promise.resolve(this)
     }
-    return this.fetch()
+    return this.fetch({ force: false })
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,9 +6,13 @@ import OBM from '../lib'
 const nr = 6
 const userId = 11
 
-const $ = global.$ = { ajax: opts => {
-  setTimeout(() => opts.success({ nr: 0, included: false, actions: '' }), 20)
-}}
+const noop = () => undefined
+const $ = global.$ = {
+  ajax: opts => {
+    setTimeout(() => opts.success({ nr: 0, included: false, actions: '' }), 20)
+  },
+  cookie: noop
+}
 
 test('mock', function (t) {
   const obm = new OBM(nr, userId)
@@ -110,6 +114,7 @@ test('getData/saveData', function (t) {
   t.equal(obm.getData(key), 'true',
     'it should return the stored string')
 
+  $.cookie = noop
   t.end()
 })
 
@@ -145,6 +150,7 @@ test('getBool/saveBool', function (t) {
   t.equal(obm.getBool(key), false,
     'should return `false` when used saveBool with `false`')
 
+  $.cookie = noop
   t.end()
 })
 
@@ -160,6 +166,7 @@ test('dataExists', function (t) {
   t.equal(obm.dataExists(key), true,
     'should return `false` when something stored')
 
+  $.cookie = noop
   t.end()
 })
 


### PR DESCRIPTION
Only the helper that triggered the initial request was updating its
OBM's data.

Also:
- adds a `force` option to `#fetch()`, which is enabled by default.
- automatically stores `was_included` cookie, and transparently uses it inside `isIncluded`
- silently doesn't send already stored actions